### PR TITLE
Configured to use custom tool-openocd

### DIFF
--- a/stm32/platformio.ini
+++ b/stm32/platformio.ini
@@ -15,6 +15,8 @@ framework = stm32cube
 lib_deps = 
     soil_power_sensor_protobuf=symlink://../proto/c
 
+platform_packages =
+    tool-openocd @ https://github.com/jlab-sensing/tool-openocd.git
 
 build_flags = 
     -DDMA_CCR_SECM
@@ -25,12 +27,14 @@ build_flags =
 build_src_filter = +<*> -<.git/> -<examples/*>
 
 # stlink
-#debug_tool = stlink
-#upload_protocol = stlink
+debug_tool = stlink
+upload_protocol = stlink
+
+debug_port = /dev/ttyACM0
 
 # black magic probe (bmp)
-debug_tool = blackmagic
-upload_protocol = blackmagic
+#debug_tool = blackmagic
+#upload_protocol = blackmagic
 
 monitor_port = /dev/ttyUSB0
 monitor_speed = 115200


### PR DESCRIPTION
Create a custom `openocd` platformio tool that allows you to insert custom `openocd` binaries. See [https://github.com/jlab-sensing/tool-openocd](https://github.com/jlab-sensing/tool-openocd), as it also has a `README`. Side node: @stevegtaylor can you update the README in the repo once you figure out the paths?

@stevegtaylor the windows versions of stm32cubeide comes with a precompiled binary that you should be able to link to your local folder allowing you to use `openocd` with the st-link. 

The following was my output when uploading via `openocd`

```
jtmadden@spruce:~/repos/jlab/soil-power-sensor-firmware/stm32 (1-integrate-uploading-of-firmwrae-through-the-pio-interface) > pio run -e stm32 -t upload                                                                       [130]
*************************************************************************************************************************************************************************************************************************************
Obsolete PIO Core v6.1.7 is used (previous was 6.1.11)
Please remove multiple PIO Cores from a system:
https://docs.platformio.org/en/latest/core/installation/troubleshooting.html
*************************************************************************************************************************************************************************************************************************************
Processing stm32 (platform: https://github.com/jlab-sensing/platform-ststm32; board: WioE5; framework: stm32cube)
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Verbose mode can be enabled via `-v, --verbose` option
CONFIGURATION: https://docs.platformio.org/page/boards/ststm32/WioE5.html
PLATFORM: ST STM32 (17.0.0+sha.7136ebc) > WioE5
HARDWARE: STM32WL55JC 48MHz, 64KB RAM, 256KB Flash
DEBUG: Current (stlink) On-board (stlink) External (blackmagic, cmsis-dap, jlink)
PACKAGES: 
 - framework-stm32cubewl @ 1.26.2+sha.77fa61b 
 - tool-dfuutil @ 1.11.0 
 - tool-dfuutil-arduino @ 1.11.0 
 - tool-ldscripts-ststm32 @ 0.2.0 
 - tool-openocd @ 1.0.0+sha.6930394 
 - tool-stm32duino @ 1.0.1 
 - toolchain-gccarmnoneeabi @ 1.70201.0 (7.2.1)
Warning! Cannot find the default startup file for `stm32wl55jc`. Ignore this warning if the startup code is part of your project.
LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
LDF Modes: Finder ~ chain, Compatibility ~ soft
Found 13 compatible libraries
Scanning dependencies...
Dependency Graph
|-- Soil Power Sensor Protocal Buffer @ 2.0.0
Building in release mode
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_adc.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_adc_ex.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_comp.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_cortex.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_crc.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_crc_ex.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_cryp.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_cryp_ex.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_dac.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_dac_ex.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_dma.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_dma_ex.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_exti.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_flash.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_flash_ex.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_gpio.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_gtzc.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_hsem.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_i2c.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_i2c_ex.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_i2s.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_ipcc.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_irda.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_iwdg.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_lptim.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_pka.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_pwr.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_pwr_ex.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_rcc.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_rcc_ex.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_rng.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_rng_ex.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_rtc.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_rtc_ex.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_smartcard.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_smartcard_ex.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_smbus.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_smbus_ex.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_spi.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_spi_ex.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_subghz.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_tim.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_tim_ex.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_uart.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_uart_ex.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_usart.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_usart_ex.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_hal_wwdg.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_ll_adc.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_ll_comp.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_ll_crc.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_ll_dac.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_ll_dma.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_ll_exti.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_ll_gpio.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_ll_i2c.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_ll_lptim.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_ll_lpuart.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_ll_pka.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_ll_pwr.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_ll_rcc.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_ll_rng.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_ll_rtc.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_ll_spi.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_ll_tim.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_ll_usart.o
Compiling .pio/build/stm32/FrameworkHALDriver/Src/stm32wlxx_ll_utils.o
Compiling .pio/build/stm32/src/adc.o
Compiling .pio/build/stm32/src/battery.o
Compiling .pio/build/stm32/src/dma.o
Compiling .pio/build/stm32/src/gpio.o
Compiling .pio/build/stm32/src/main.o
Compiling .pio/build/stm32/src/startup_stm32wl55xx_cm4.o
Compiling .pio/build/stm32/src/stm32wlxx_hal_msp.o
Compiling .pio/build/stm32/src/stm32wlxx_it.o
Compiling .pio/build/stm32/src/usart.o
Compiling .pio/build/stm32/libecd/c/pb_common.o
Compiling .pio/build/stm32/libecd/c/pb_decode.o
Compiling .pio/build/stm32/libecd/c/pb_encode.o
Compiling .pio/build/stm32/libecd/c/soil_power_sensor.pb.o
Compiling .pio/build/stm32/libecd/c/timestamp.pb.o
Compiling .pio/build/stm32/FrameworkCMSISDevice/system_stm32wlxx.o
Archiving .pio/build/stm32/libecd/libc.a
Indexing .pio/build/stm32/libecd/libc.a
Archiving .pio/build/stm32/libFrameworkCMSISDevice.a
Indexing .pio/build/stm32/libFrameworkCMSISDevice.a
Linking .pio/build/stm32/firmware.elf
Checking size .pio/build/stm32/firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [          ]   0.8% (used 508 bytes from 65536 bytes)
Flash: [          ]   4.7% (used 12352 bytes from 262144 bytes)
Configuring upload protocol...
AVAILABLE: blackmagic, cmsis-dap, jlink, mbed, stlink
CURRENT: upload_protocol = stlink
Uploading .pio/build/stm32/firmware.elf
Open On-Chip Debugger 0.12.0-00017-g26301c4dd (2023-12-01-17:06) [https://github.com/STMicroelectronics/OpenOCD]
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
debug_level: 1

hla_swd
none separate

[stm32wlx.cpu0] halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x08002594 msp: 0x20008000
** Programming Started **
Warn : Adding extra erase range, 0x08003190 .. 0x080037ff
** Programming Finished **
** Verify Started **
** Verified OK **
** Resetting Target **
shutdown command invoked
==================================================================================================== [SUCCESS] Took 6.40 seconds ====================================================================================================

Environment    Status    Duration
-------------  --------  ------------
stm32          SUCCESS   00:00:06.400
==================================================================================================== 1 succeeded in 00:00:06.400 ====================================================================================================
```

This is not that far from being able to be used as a debugger. It would be a matter of modifying the `openocd` flash script to configure it for debugger. Aka rather than shutdown you just go into a reset state. 