### PR TITLE
Fixed debugging with openocd and stlink

### DIFF
--- a/stm32/platformio.ini
+++ b/stm32/platformio.ini
@@ -36,39 +36,25 @@ build_src_filter = +<*> -<.git/> -<examples/*>
 # stlink
 debug_tool = stlink
 upload_protocol = stlink
-
-extra_scripts = pre:tool_openocd.py  ; Add this line
-
-debug_port = COM3
-upload_port = COM3
+#
+#extra_scripts = pre:tool_openocd.py  ; Add this line
+#
+debug_port = localhost:3333
+upload_port = /dev/ttyACM0
 
 # black magic probe (bmp)
 #debug_tool = blackmagic
 #upload_protocol = blackmagic
 
-monitor_port = COM11
+monitor_port = /dev/ttyUSB0
 monitor_speed = 115200
 
-test_port = COM11
+test_port = /dev/ttyUSB0
 test_speed = 115200
 
-[env_debug]
-platform = ${env.platform}
-board = ${env.board}
-framework = ${env.framework}
-lib_deps = ${env.lib_deps}
-platform_packages = ${env.platform_packages}
-build_flags = ${env.build_flags}
-build_src_filter = ${env.build_src_filter}
-debug_tool = ${env.debug_tool}
-upload_protocol = ${env.upload_protocol}
-debug_server =
-    gdb_port = 3333
-    telnet_port = 4444
-    tcl_port = 6666
-    debug_level = 3 ; Set the debug level to 3
+#debug_init_break = tbreak main
 
-board_build.stm32cube.custom_config_header = yes
+#board_build.stm32cube.custom_config_header = yes
 
 [env:stm32]
 
@@ -84,7 +70,7 @@ build_src_filter = +<*> -<.git/> -<main.c> -<examples/*>
 test_build_src = true
 
 # uncomment with the test name to debug a test
-debug_test = test_transcoder
+debug_test = test_fifo
 
 [platformio]
 include_dir = Inc


### PR DESCRIPTION
**Purpose of the PR**
Correctly configure debugging for the st-link debugger

**Development Environment**
`Linux spruce 6.8.2-arch2-1 #1 SMP PREEMPT_DYNAMIC Thu, 28 Mar 2024 17:06:35 +0000 x86_64 GNU/Linux`
`PlatformIO Core, version 6.1.7`
Used _ST-Link V3 MINIE_

**Test Procedure**
Start the debugger for `example_adc` environment in vscode

**Additional Context**
The implementation of `openocd` with st-link starts a gdb server on the local machine. You can then use a gdb client to connect to a remote target and debug. There's some configuration that is applied from `.pioinit` that is dynamically generated in `~/.platformio/.cache/.piodebug-xxxx/.pioinit`. This means that we are not directly interfacing with the st-link through USB, therefore `debug_port = /dev/ttyACM0` is not correct. Replacing with the gdb server port, ie. `debug_port = localhost:3333` it works. It appears that this is a constant.

Closes #1 