### PR TITLE
Fix ads unit tests

### DIFF
--- a/stm32/Src/ads.c
+++ b/stm32/Src/ads.c
@@ -12,6 +12,21 @@
 /* Includes ------------------------------------------------------------------*/
 #include "ads.h"
 
+#include <stm32wlxx_hal_gpio.h>
+
+/**
+ * @brief GPIO port for adc data ready line
+ * 
+ * @see data_ready_pin
+ */
+const GPIO_TypeDef* data_ready_port = GPIOC;
+
+/**
+ * @brief GPIO pin for adc data ready line
+ * 
+ */
+const uint16_t data_ready_pin = GPIO_PIN_0;
+
 int HAL_status(HAL_StatusTypeDef ret) {
   int status;
   if (ret == HAL_OK){
@@ -88,7 +103,7 @@ double ADC_readVoltage(void){
     return -1;
   }
     
-  while((HAL_GPIO_ReadPin(GPIOA, GPIO_PIN_3))); // Wait for the DRDY pin on the ADS12 to go low, this means data is ready
+  while(HAL_GPIO_ReadPin(data_ready_port, data_ready_pin)); // Wait for the DRDY pin on the ADS12 to go low, this means data is ready
   code = ADS12_READ_DATA_CODE;
   ret = HAL_I2C_Master_Transmit(&hi2c2, ADS12_WRITE, &code, 1, HAL_MAX_DELAY);
   if (ret != HAL_OK){
@@ -123,7 +138,7 @@ double ADC_readCurrent(void){
     return -1;
   }
     
-  while((HAL_GPIO_ReadPin(GPIOA, GPIO_PIN_3))); // Wait for the DRDY pin on the ADS12 to go low, this means data is ready
+  while(HAL_GPIO_ReadPin(data_ready_port, data_ready_pin)); // Wait for the DRDY pin on the ADS12 to go low, this means data is ready
   code = ADS12_READ_DATA_CODE;
   ret = HAL_I2C_Master_Transmit(&hi2c2, ADS12_WRITE, &code, 1, HAL_MAX_DELAY);
   if (ret != HAL_OK){

--- a/stm32/platformio.ini
+++ b/stm32/platformio.ini
@@ -37,20 +37,20 @@ build_src_filter = +<*> -<.git/> -<examples/*>
 debug_tool = stlink
 upload_protocol = stlink
 #
-extra_scripts = pre:tool_openocd.py  ; Add this line
+#extra_scripts = pre:tool_openocd.py  ; Add this line
 #
 debug_port = localhost:3333
-upload_port = COM14
+upload_port = /dev/ttyACM0
 
 
 # black magic probe (bmp)
 #debug_tool = blackmagic
 #upload_protocol = blackmagic
 
-monitor_port = COM12
+monitor_port = /dev/ttyUSB0
 monitor_speed = 115200
 
-test_port = COM12
+test_port = /dev/ttyUSB0
 test_speed = 115200
 
 #debug_init_break = tbreak main
@@ -74,13 +74,12 @@ build_src_filter = +<*> -<.git/> -<main.c> -<examples/**> +<examples/calibrate_a
 [env:example_sdi12]
 build_src_filter = +<*> -<.git/> -<main.c> -<examples/**> +<examples/example_sdi12.c>
 
-#[env:tests]
-#build_type = debug
-#build_src_filter = +<*> -<.git/> -<main.c> -<examples/*>
-#test_build_src = true
+[env:tests]
+build_type = debug
+build_src_filter = +<*> -<.git/> -<main.c> -<examples/*>
+test_build_src = true
 
-# uncomment with the test name to debug a test
-#debug_test = test_transcoder
+debug_test = test_ads
 
 [platformio]
 include_dir = Inc

--- a/stm32/test/test_ads/test_ads.c
+++ b/stm32/test/test_ads/test_ads.c
@@ -10,6 +10,8 @@
 #include "i2c.h"
 #include "usart.h"
 #include "gpio.h"
+#include "sys_app.h"
+
 #include "fifo.h"
 #include "ads.h"
 
@@ -66,6 +68,7 @@ int main(void)
   MX_USART1_UART_Init();
   MX_I2C2_Init();
   /* USER CODE BEGIN 2 */
+  UTIL_TIMER_Init();
 
   // wait for UART
   for (int i = 0; i < 1000000; i++) {


### PR DESCRIPTION
**Name/Affiliation/Title**
John, maintainer

**Purpose of the PR**
Fixes `test_ads` hanging

**Development Environment**
`Linux spruce 6.8.2-arch2-1 #1 SMP PREEMPT_DYNAMIC Thu, 28 Mar 2024 17:06:35 +0000 x86_64 GNU/Linux`
PlatformIO Core, version 6.1.7
Used ST-Link V3 MINIE

**Test Procedure**
Run the following and check that the tests passes
```
pio test -e tests -f test_ads
```

**Additional Context**
Added timer initialization to `test_ads.c` since the library relies on `HAL_Delay`. Also updated the data ready pin as that was incorrect.

Closes #83 