### PR TITLE
Fix main code hanging

### DIFF
--- a/stm32/Inc/sensors.h
+++ b/stm32/Inc/sensors.h
@@ -22,8 +22,8 @@
  * is defined by APP_TX_DUTY_CYCLE.
  */
 
-#ifndef __SENSORS_H__
-#define __SENSORS_H__
+#ifndef __USER_SENSORS_H__
+#define __USER_SENSORS_H__
 
 #include "stm32_seq.h"
 #include "stm32_timer.h"
@@ -43,7 +43,7 @@ extern "C"{
 
 #ifndef MEASUREMENT_PERIOD
 /** The amount of time between measurements */
-#define MEASUREMENT_PERIOD 1000
+#define MEASUREMENT_PERIOD 10000
 #endif /* MEASUREMENT_PERIOD */
 
 /**
@@ -86,4 +86,4 @@ int SensorsAdd(SensorsPrototypeMeasure cb);
 }
 #endif
 
-#endif // __SENSORS_H__
+#endif // __USER_SENSORS_H__

--- a/stm32/Src/adc_if.c
+++ b/stm32/Src/adc_if.c
@@ -128,7 +128,7 @@ int16_t SYS_GetTemperatureLevel(void)
   uint32_t measuredLevel = 0;
   uint16_t batteryLevelmV = SYS_GetBatteryLevel();
 
-  measuredLevel = ADC_ReadChannels(ADC_CHANNEL_TEMPSENSOR);
+  measuredLevel = ADC_ReadChannels(1);
 
   /* convert ADC level to temperature */
   /* check whether device has temperature sensor calibrated in production */
@@ -169,7 +169,7 @@ uint16_t SYS_GetBatteryLevel(void)
   uint16_t batteryLevelmV = 0;
   uint32_t measuredLevel = 0;
 
-  measuredLevel = ADC_ReadChannels(ADC_CHANNEL_VREFINT);
+  measuredLevel = ADC_ReadChannels(2);
 
   if (measuredLevel == 0)
   {
@@ -220,42 +220,7 @@ static uint32_t ADC_ReadChannels(uint32_t channel)
   /* USER CODE BEGIN ADC_ReadChannels_1 */
 
   /* USER CODE END ADC_ReadChannels_1 */
-  uint32_t ADCxConvertedValues = 0;
-  ADC_ChannelConfTypeDef sConfig = {0};
-
-  MX_ADC_Init();
-
-  /* Start Calibration */
-  if (HAL_ADCEx_Calibration_Start(&hadc) != HAL_OK)
-  {
-    Error_Handler();
-  }
-
-  /* Configure Regular Channel */
-  sConfig.Channel = channel;
-  sConfig.Rank = ADC_REGULAR_RANK_1;
-  sConfig.SamplingTime = ADC_SAMPLINGTIME_COMMON_1;
-  if (HAL_ADC_ConfigChannel(&hadc, &sConfig) != HAL_OK)
-  {
-    Error_Handler();
-  }
-
-  if (HAL_ADC_Start(&hadc) != HAL_OK)
-  {
-    /* Start Error */
-    Error_Handler();
-  }
-  /** Wait for end of conversion */
-  HAL_ADC_PollForConversion(&hadc, HAL_MAX_DELAY);
-
-  /** Wait for end of conversion */
-  HAL_ADC_Stop(&hadc);   /* it calls also ADC_Disable() */
-
-  ADCxConvertedValues = HAL_ADC_GetValue(&hadc);
-
-  HAL_ADC_DeInit(&hadc);
-
-  return ADCxConvertedValues;
+  return adc_values[channel];
   /* USER CODE BEGIN ADC_ReadChannels_2 */
 
   /* USER CODE END ADC_ReadChannels_2 */

--- a/stm32/Src/lora_app.c
+++ b/stm32/Src/lora_app.c
@@ -221,19 +221,6 @@ static void OnPingSlotPeriodicityChanged(uint8_t pingSlotPeriodicity);
 static void OnSystemReset(void);
 
 /* USER CODE BEGIN PFP */
-/**
- * @brief Time synchronization timer callback
- *
- * Registers TimeSync task with the synchronizer.
- */
-static void OnTimeSync(void);
-
-/**
- * @brief Requests a time synchronization from the application server
- *
- * Once the synchronization is completed the timer is stopped.
- */
-static void TimeSync(void);
 /* USER CODE END PFP */
 
 /* Private variables ---------------------------------------------------------*/
@@ -319,16 +306,6 @@ static uint8_t AppDataBuffer[LORAWAN_APP_DATA_BUFFER_MAX_SIZE];
  */
 static LmHandlerAppData_t AppData = {0, 0, AppDataBuffer};
 
-/**
- * @brief Timer for repeated time sync events
- */
-static UTIL_TIMER_Object_t TimeSyncTimer;
-
-/**
- * @brief Period for time sync events
- */
-static const UTIL_TIMER_Time_t TimeSyncPeriod = TIMESYNC_PERIOD;
-
 /* USER CODE END PV */
 
 /* Exported functions ---------------------------------------------------------*/
@@ -406,35 +383,6 @@ void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin)
 
 /* Private functions ---------------------------------------------------------*/
 /* USER CODE BEGIN PrFD */
-
-void OnTimeSync(void)
-{
-  // schedule task in sequencer
-  UTIL_SEQ_SetTask((1 << CFG_SEQ_Task_TimeSync), CFG_SEQ_Prio_0);
-}
-
-void TimeSync(void)
-{
-  // try to sync the clock
-  LmHandlerErrorStatus_t status = LmhpClockSyncAppTimeReq();
-  if (status == LORAMAC_HANDLER_SUCCESS)
-  {
-    // stop timer
-    UTIL_TIMER_Stop(&TimeSyncTimer);
-
-
-    // start sensor measurements
-    SensorsStart();
-
-    APP_LOG(TS_ON, VLEVEL_M, "Clock initiated\r\n");
-  }
-  else
-  {
-    APP_LOG(TS_OFF, VLEVEL_M,
-            "Clock synchronization failed. Retrying in %u ms.\r\n",
-            TimeSyncPeriod)
-  }
-}
 
 /* USER CODE END PrFD */
 


### PR DESCRIPTION
**Name/Affiliation/Title**
John, maintainer

**Purpose of the PR**
Get our main firmware running

**Development Environment**
`Linux spruce 6.8.2-arch2-1 #1 SMP PREEMPT_DYNAMIC Thu, 28 Mar 2024 17:06:35 +0000 x86_64 GNU/Linux`
PlatformIO Core, version 6.1.7
Used ST-Link V3 MINIE

**Test Procedure**
Flash the `[env:stm32]` environment on the board
```
pio run -t upload -t monitor
```

**Additional Context**
I think the main issue causing the hang was ADC initialization code in `adc_if.c`. Looks like it got rewrote at some point by CubeMX. I also fixed duplicate include guards between `sys_sensors.h` and `sensors.h` and increased the measurement frequency. The time sync code was also rewritten to be inside of `SendTxData` so that all `LmHandlerSend` is included within that function call.

Closes #85 