### PR TITLE
Fix stm32 build action

### DIFF
--- a/stm32/platformio.ini
+++ b/stm32/platformio.ini
@@ -89,3 +89,5 @@ debug_test = test_ads
 [platformio]
 include_dir = Inc
 src_dir = Src
+
+default_envs = stm32, example_battery, example_adc, example_phytos, calibrate_adc, example_sdi12


### PR DESCRIPTION
**Name/Affiliation/Title**
John Madden, UCSC, Maintainer

**Purpose of the PR**
Fix the stm32 build action. The action is currently set to build the `tests` env which will always fail since it does not have access to main files within the test folders.

**Development Environment**
`Linux spruce 6.8.2-arch2-1 #1 SMP PREEMPT_DYNAMIC Thu, 28 Mar 2024 17:06:35 +0000 x86_64 GNU/Linux`
PlatformIO Core, version 6.1.7
Used ST-Link V3 MINIE

**Test Procedure**
Run the action build command with the following
```
pio run
```

**Additional Context**
N/A