### PR TITLE
fixed 2s complement

### DIFF
--- a/stm32/Src/ads.c
+++ b/stm32/Src/ads.c
@@ -114,7 +114,13 @@ double ADC_readVoltage(void){
     return -1;
   }
 
-  uint64_t temp = ((uint64_t)rx_data[0] << 16) | ((uint64_t)rx_data[1] << 8) | ((uint64_t)rx_data[2]); 
+  // Combine the 3 bytes into a 24-bit value
+  int32_t temp = ((int32_t)rx_data[0] << 16) | ((int32_t)rx_data[1] << 8) | ((int32_t)rx_data[2]);
+  // Check if the sign bit (24th bit) is set
+  if (temp & 0x800000) {
+      // Extend the sign to 32 bits
+      temp |= 0xFF000000;
+  }
   reading = (double) temp;
 
   // Uncomment these lines if you wish to see the raw and shifted values from the ADC for calibration purpouses


### PR DESCRIPTION
---
name: Fixed ADC shifting to accommodate 2s complement 
about: Fixed 2s complement for a smoother full scale range
title: ''
labels: ''
assignees: ''
reviewers: 'jmadden173'
---


**Purpose of the PR**
Minor changes to ADC_readVoltage in order to get a smooth full scale input,

**Development Environment**
Windows

**Test Procedure**
Plug a SPS into a DC power supply and move back and forth across positive and negative voltages.

**Additional Context**
N/A
